### PR TITLE
Show arcade mode instructions on web demo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -273,13 +273,15 @@
             </ul>
         </div>
 
-        <div id="arcadeInstructions" class="instructions" style="display: none;">
+        <div id="arcadeInstructions" class="instructions">
             <h3>Arcade Mode: The Hunt for the One True FUCK</h3>
-            <p>A single fuck is given… unless it isn’t.</p>
-            <p>Spot it quick to rise through the levels.</p>
-            <p>Think there are none? Smash "No Fucks Given."</p>
-            <p>Three lives only. Out of fucks, out of luck.</p>
-            <p>There maybe something else to look for, who knows?</p>
+            <ul>
+                <li>A single fuck is given… unless it isn’t.</li>
+                <li>Spot it quick to rise through the levels.</li>
+                <li>Think there are none? Smash "No Fucks Given."</li>
+                <li>Three lives only. Out of fucks, out of luck.</li>
+                <li>There may be something else to look for, who knows?</li>
+            </ul>
         </div>
         
         <div class="controls">


### PR DESCRIPTION
## Summary
- Display arcade mode instructions on the demo page by removing hidden style
- Format arcade rules as an easy-to-read bullet list

## Testing
- `python hmf_tests.py` *(fails: ModuleNotFoundError: No module named 'hmf')*

------
https://chatgpt.com/codex/tasks/task_e_68ac7bf21254832781fed157f783514e